### PR TITLE
Correctly support WS-Security, add integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
-/vendor
-.project
-composer.phar
-/target
-composer.lock
 .idea
+.project
+
+composer.lock
+it-configuration.ini
+
+/target
+/vendor
+
 *.iml
+*.phar

--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ Here is some example code for version 1.5 of the CAOS API.
 
 ``` php
 // Code to request the present term
-$ChubService = new edu\wisc\service\caos\ChubService();
-$request = new edu\wisc\service\caos\GetPresentTermRequest($courseCareerCode);
+$ChubService = new edu\wisc\services\caos\ChubService();
+$request = new edu\wisc\services\caos\GetPresentTermRequest($courseCareerCode);
 $reponse = $ChubService->GetPresentTerm($request);
 // Code here to extract data from response
 unlink($request, $response);
 
 // Code to request a class (ChubService is already initialized so it need not be declared again)
-$request = new edu\wisc\service\caos\GetClassRequest($classID);
+$request = new edu\wisc\services\caos\GetClassRequest($classID);
 $response = $ChubService->GetClass($request);
 // Code here to extract data from response
 unlink($request, $response);
 
 // Code to request a list of advisors
-$request = new edu\wisc\service\caos\GetAdvisorsRequest($personQuery, $advisingDataOptions, $attributes);
+$request = new edu\wisc\services\caos\GetAdvisorsRequest($personQuery, $advisingDataOptions, $attributes);
 $reponse = $ChubService->GetAdvisors($request);
 // Code here to extract data from response
 unlink($request, $response);

--- a/README.md
+++ b/README.md
@@ -54,20 +54,22 @@ Issuing requests with the CAOS API follows this framework.
 Here is some example code for version 1.5 of the CAOS API.
 
 ``` php
-// Code to request the present term
-$ChubService = new edu\wisc\services\caos\ChubService();
+// acquire an instance from ChubServiceFactory
+$ChubService = edu\wisc\services\caos\ChubServiceFactory::getInstance('myusername', 'mypassword');
+
+// Request the present term
 $request = new edu\wisc\services\caos\GetPresentTermRequest($courseCareerCode);
 $reponse = $ChubService->GetPresentTerm($request);
 // Code here to extract data from response
 unlink($request, $response);
 
-// Code to request a class (ChubService is already initialized so it need not be declared again)
+// Request a class (ChubService is already initialized so it need not be declared again)
 $request = new edu\wisc\services\caos\GetClassRequest($classID);
 $response = $ChubService->GetClass($request);
 // Code here to extract data from response
 unlink($request, $response);
 
-// Code to request a list of advisors
+// Request a list of advisors
 $request = new edu\wisc\services\caos\GetAdvisorsRequest($personQuery, $advisingDataOptions, $attributes);
 $reponse = $ChubService->GetAdvisors($request);
 // Code here to extract data from response

--- a/build.xml
+++ b/build.xml
@@ -30,5 +30,26 @@
 		<exec command="php release.php ${targetDir} ${version} ${branch}" passthru="true" checkreturn="true" />
 	</target>
 
+	<!-- Downloads phpunit.phar -->
+	<target name="get-phpunit">
+		<if>
+			<not>
+				<available file="phpunit.phar" />
+			</not>
+			<then>
+				<echo msg="phpunit.phar not found. Downloading..." />
+				<httpget url="https://phar.phpunit.de/phpunit.phar" sslVerifyPeer="false" dir="."/>
+			</then>
+			<else>
+				<echo msg="phpunit.phar already exists" />
+			</else>
+		</if>
+	</target>
+	
+	<!-- runs phpunit 'integration'tests -->
+	<target name="phpunit-integration" depends="get-phpunit">
+		<exec command="php phpunit.phar -c src/test/phpunit-integration.xml" passthru="true" dir="."
+		checkreturn="true" />
+	</target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -48,7 +48,7 @@
 	
 	<!-- runs phpunit 'integration'tests -->
 	<target name="phpunit-integration" depends="get-phpunit">
-		<exec command="php phpunit.phar -c src/test/phpunit-integration.xml" passthru="true" dir="."
+		<exec command="php phpunit.phar -c phpunit-integration.xml" passthru="true" dir="."
 		checkreturn="true" />
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
 	"name": "uwmadison_doit/caos-php-client",
 	"description": "A PHP client used to connect with the CAOS API and perform requests",
-	"homepage": "https://bitbucket.org/uwmadison_doit/caos-php-client",
   	"license": "Apache-2.0",
+	"homepage": "https://wiki.doit.wisc.edu/confluence/pages/viewpage.action?pageId=47562009",
 	"authors": [
 		{
 			"name": "UW-Madison DoIT ADI Internal Applications",
@@ -12,7 +12,7 @@
 	],
 	"support": {
 		"email": "adi-ia@lists.wisc.edu",
-		"source": "https://bitbucket.org/uwmadison_doit/caos-php-client"
+		"source": "https://github.com/cknuth/caos-php-client"
 	},
 
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"support": {
 		"email": "adi-ia@lists.wisc.edu",
-		"source": "https://github.com/cknuth/caos-php-client"
+		"source": "https://github.com/UW-Madison-DoIT/caos-php-client"
 	},
 
 	"require": {

--- a/get-phing.sh
+++ b/get-phing.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+wget http://www.phing.info/get/phing-latest.phar -O phing.phar

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../../vendor/autoload.php"
+<phpunit bootstrap="./vendor/autoload.php"
 		 backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -13,7 +13,7 @@
 >
     <testsuites>
         <testsuite name="Integration Tests">
-            <directory>./integration</directory>
+            <directory>./src/test/integration</directory>
         </testsuite>
     </testsuites>
     

--- a/src/main/ChubServiceFactory.php
+++ b/src/main/ChubServiceFactory.php
@@ -17,7 +17,7 @@ class ChubServiceFactory {
 	 * @param string $username ESB service account username
 	 * @param string $password ESB service account password
 	 * @param string $wsdl
-	 * @return a new instance of \edu\wisc\services\caos\ChubService
+	 * @return edu\wisc\services\caos\ChubService
 	 */
 	public static function getInstance($username, $password, $wsdl = null) {
 		$service = null;

--- a/src/main/ChubServiceFactory.php
+++ b/src/main/ChubServiceFactory.php
@@ -1,0 +1,40 @@
+<?php 
+
+namespace edu\wisc\services\caos;
+
+/**
+ * Static factory for instantiating {@link edu\wisc\services\caos\ChubService} instances.
+ * 
+ * @author Nicholas Blair
+ */
+class ChubServiceFactory {
+	
+	/**
+	 * Returns a new instance of {@link edu\wisc\services\caos\ChubService}. Encapsulates
+	 * the magic in setting up the underlying PHP SoapClient to add WS-Security headers
+	 * to outgoing requests.
+	 * 
+	 * @param string $username ESB service account username
+	 * @param string $password ESB service account password
+	 * @param string $wsdl
+	 * @return a new instance of \edu\wisc\services\caos\ChubService
+	 */
+	public static function getInstance($username, $password, $wsdl = null) {
+		$service = null;
+		if(is_null($wsdl)) {
+			$service = new ChubService();
+		} else {
+			$service = new ChubService(array(), $wsdl);
+		}
+		$namespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
+		$token = new \stdClass;
+		$token->Username = new \SoapVar($username, XSD_STRING, null, null, null, $namespace);
+		$token->Password = new \SoapVar($password, XSD_STRING, null, null, null, $namespace);
+		$wsec = new \stdClass;
+		$wsec->UsernameToken = new \SoapVar($token, SOAP_ENC_OBJECT, null, null, null, $namespace);
+		$headers = new \SOAPHeader($namespace, 'Security', $wsec, true);
+		$service->__setSOAPHeaders($headers);
+		
+		return $service;
+	}
+}

--- a/src/test/integration/ChubServiceIntegrationTest.php
+++ b/src/test/integration/ChubServiceIntegrationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use edu\wisc\services\caos\ChubService;
+
+/**
+ * Integration tests for {@link ChubService}
+ * 
+ * @author Nicholas Blair
+ */
+class ChubServiceIntegrationTest extends PHPUnit_Framework_TestCase
+{
+	
+	const TEST_CONFIGURATION_FILE = 'it-configuration.ini';
+	
+	/** @var array  integration test configuration parsed by {@link parse_ini_file} */
+	protected static $testConfiguration;
+	
+	/**
+	 * Parses the integration test data and creates an instance of {@link WiscList_Config}
+	 * @throws \RuntimeException  if unable to parse test data
+	 */
+	public static function setUpBeforeClass()
+	{
+		$iniFile = __DIR__ . '/' . static::TEST_CONFIGURATION_FILE;
+		static::$testConfiguration = parse_ini_file($iniFile, INI_SCANNER_RAW);
+		if (static::$testConfiguration === false) {
+			throw new \RuntimeException("Unable to parse $iniFile");
+		}
+	}
+	
+	/**
+	 * Returns the value of the specified configuration option
+	 *
+	 * @param string $key  property key 
+	 * @return string  property value 
+	 * @throws \RuntimeException  if the key cannot be found
+	 */
+	public static function getConfigurationValue($key)
+	{
+		if (!isset(static::$testConfiguration[$key])) {
+			throw new \RuntimeException("Integration test property not found with key: $key");
+		}
+		return strval(static::$testConfiguration[$key]);
+	}
+	
+	/**
+	 * Call getPresentTerm, confirm successful response.
+	 */
+	public function testGetPresentTerm() {
+		$service = new edu\wisc\services\caos\ChubService(
+				array('login'          => static::getConfigurationValue('caos.username'),
+                      'password'       => static::getConfigurationValue('caos.password'))
+				);
+		$request = new edu\wisc\services\caos\GetPresentTermRequest(null);
+		$response = $service->GetPresentTerm($request);
+		var_dump($response);
+		$this->assertTrue(false);
+	}
+}

--- a/src/test/integration/ChubServiceIntegrationTest.php
+++ b/src/test/integration/ChubServiceIntegrationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use edu\wisc\services\caos\ChubService;
-
 /**
  * Integration tests for {@link ChubService}
  * 
@@ -47,13 +45,11 @@ class ChubServiceIntegrationTest extends PHPUnit_Framework_TestCase
 	 * Call getPresentTerm, confirm successful response.
 	 */
 	public function testGetPresentTerm() {
-		$service = new edu\wisc\services\caos\ChubService(
-				array('login'          => static::getConfigurationValue('caos.username'),
-                      'password'       => static::getConfigurationValue('caos.password'))
-				);
+		$service = edu\wisc\services\caos\ChubServiceFactory::getInstance(static::getConfigurationValue('caos.username'), static::getConfigurationValue('caos.password'));
+		
 		$request = new edu\wisc\services\caos\GetPresentTermRequest(null);
 		$response = $service->GetPresentTerm($request);
-		var_dump($response);
-		$this->assertTrue(false);
+		$this->assertInstanceOf('edu\wisc\services\caos\GetPresentTermResponse', $response);
+		$this->assertTrue(strlen($response->getTerm()->getTermCode()) === 4);
 	}
 }

--- a/src/test/integration/it-configuration-SAMPLE.ini
+++ b/src/test/integration/it-configuration-SAMPLE.ini
@@ -1,0 +1,3 @@
+; provide your ESB credentials here
+caos.username=someusername
+caos.password=somepassword

--- a/src/test/phpunit-integration.xml
+++ b/src/test/phpunit-integration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../main/autoload.php"
+<phpunit bootstrap="../../vendor/autoload.php"
 		 backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"

--- a/src/test/phpunit-integration.xml
+++ b/src/test/phpunit-integration.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../main/autoload.php"
+		 backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Integration Tests">
+            <directory>./integration</directory>
+        </testsuite>
+    </testsuites>
+    
+</phpunit>


### PR DESCRIPTION
The CHUB service expects credentials to be relayed via WS-Security, which the previous implementation wasn't doing. Adds a static factory as well to help construct `ChubService` instances.

.gitignore gets shuffled around a little bit, sorted alpha-sensibly.
