### PR TITLE
Remove PHP 5.3 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,6 @@
 		"email": "adi-ia@lists.wisc.edu",
 		"source": "https://github.com/cknuth/caos-php-client"
 	},
-
-	"require": {
-		"php": "^5.3.0"
-	},
 	"require-dev": {
 		"phing/phing": "2.11.0",
 		"wsdl2phpgenerator/wsdl2phpgenerator": "3.2.0",


### PR DESCRIPTION
Remove PHP 5.3 requirement, as this code base is compatible with all current versions of PHP.

I ran a PHP 7 compatibility check on this code, which returned no issues.
